### PR TITLE
Fix doc comment for sanitize_path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub mod routes;
 pub const UPLOAD_PATH: &str = "./upload/";
 
 /// Returns `None` if the path is invalid (e.g., contains `..`)
-/// Trims leading slash
+/// Trims leading slashes
 fn sanitize_path(input: &str) -> Option<PathBuf> {
     let trimmed = input.trim_start_matches('/');
     let path = Path::new(trimmed);


### PR DESCRIPTION
## Summary
- clarify sanitize_path description to note trimming of all leading slashes

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687cfd4ad5d8832fb4f80ac7e6fb360c